### PR TITLE
__do_fork 내의 process_init 위치 변경

### DIFF
--- a/pintos-kaist/tests/userprog/fork-read.c
+++ b/pintos-kaist/tests/userprog/fork-read.c
@@ -1,5 +1,5 @@
-/* After fork, the child process will read and close the opened file
-   and the parent will access the closed file. */
+/* fork 이후, 자식 프로세스가 열린 파일을 읽고 닫으며,
+  부모 프로세스는 닫힌 파일에 접근하게 됩니다. */
 
 #include <string.h>
 #include <syscall.h>
@@ -8,50 +8,55 @@
 #include "tests/lib.h"
 #include "tests/main.h"
 
-void
-test_main (void) 
+void test_main(void)
 {
   pid_t pid;
   int handle;
   int byte_cnt;
   char *buffer;
 
-  CHECK ((handle = open ("sample.txt")) > 1, "open \"sample.txt\"");
-  buffer = get_boundary_area () - sizeof sample / 2;
-  byte_cnt = read (handle, buffer, 20);
-  
-  if ((pid = fork("child"))){
-    wait (pid);
+  CHECK((handle = open("sample.txt")) > 1, "open \"sample.txt\"");
+  buffer = get_boundary_area() - sizeof sample / 2;
+  byte_cnt = read(handle, buffer, 20);
 
-    byte_cnt = read (handle, buffer + 20, sizeof sample - 21);
+  if ((pid = fork("child")))
+  {
+    wait(pid);
+
+    byte_cnt = read(handle, buffer + 20, sizeof sample - 21);
     if (byte_cnt != sizeof sample - 21)
-      fail ("read() returned %d instead of %zu", byte_cnt, sizeof sample - 21);
-    else if (strcmp (sample, buffer)) {
-        msg ("expected text:\n%s", sample);
-        msg ("text actually read:\n%s", buffer);
-        fail ("expected text differs from actual");
-    } else {
-      msg ("Parent success");
+      fail("read() returned %d instead of %zu", byte_cnt, sizeof sample - 21);
+    else if (strcmp(sample, buffer))
+    {
+      msg("expected text:\n%s", sample);
+      msg("text actually read:\n%s", buffer);
+      fail("expected text differs from actual");
+    }
+    else
+    {
+      msg("Parent success");
     }
 
     close(handle);
-  } else {
-    msg ("child run");
+  }
+  else
+  {
+    msg("child run");
 
-    byte_cnt = read (handle, buffer + 20, sizeof sample - 21);
+    byte_cnt = read(handle, buffer + 20, sizeof sample - 21);
     if (byte_cnt != sizeof sample - 21)
-      fail ("read() returned %d instead of %zu", byte_cnt, sizeof sample - 21);
-    else if (strcmp (sample, buffer)) 
-      {
-        msg ("expected text:\n%s", sample);
-        msg ("text actually read:\n%s", buffer);
-        fail ("expected text differs from actual");
-      }
+      fail("read() returned %d instead of %zu", byte_cnt, sizeof sample - 21);
+    else if (strcmp(sample, buffer))
+    {
+      msg("expected text:\n%s", sample);
+      msg("text actually read:\n%s", buffer);
+      fail("expected text differs from actual");
+    }
 
     char magic_sentence[17] = "pintos is funny!";
     memcpy(buffer, magic_sentence, 17);
 
-    msg ("Child: %s", buffer);
+    msg("Child: %s", buffer);
     close(handle);
   }
 }

--- a/pintos-kaist/userprog/process.c
+++ b/pintos-kaist/userprog/process.c
@@ -39,6 +39,7 @@ static void process_init(void)
 {
 	struct thread *current = thread_current();
 	current->fd_table = calloc(MAX_FD, sizeof(struct file *));
+	ASSERT(current->fd_table != NULL);
 	current->fork_sema = malloc(sizeof(struct semaphore));
 	sema_init(current->fork_sema, 0);
 	ASSERT(current->fd_table != NULL);
@@ -188,22 +189,22 @@ __do_fork(void *aux)
 		goto error;
 #endif
 
+	process_init();
 	/* TODO: 이 아래에 코드를 작성해야 합니다.
 	 * TODO: 힌트) 파일 객체를 복제하려면 include/filesys/file.h의 `file_duplicate`를 사용하세요.
 	 * TODO:       이 함수가 부모의 자원을 성공적으로 복제할 때까지 부모는 fork()에서 반환되면 안 됩니다. */
 	/* 부모의 fd_table을 순회하며 복사 */
-	if (parent->fd_table[0] != NULL)
-		current->fd_table[0] = parent->fd_table[0]; // 표준 입력
-	if (parent->fd_table[1] != NULL)
-		current->fd_table[1] = parent->fd_table[1]; // 표준 출력
-	for (int i = 2; i < MAX_FD; i++)
+	// if (parent->fd_table[0] != NULL)
+	// 	current->fd_table[0] = parent->fd_table[0]; // 표준 입력
+	// if (parent->fd_table[1] != NULL)
+	// 	current->fd_table[1] = parent->fd_table[1]; // 표준 출력
+	for (int i = 0; i < MAX_FD; i++)
 	{
 		if (parent->fd_table[i] != NULL)
 			current->fd_table[i] = file_duplicate(parent->fd_table[i]);
 	}
 
 	if_.R.rax = 0;
-	process_init();
 
 	/* 마침내 새로 생성된 프로세스로 전환합니다. */
 	sema_up(parent->fork_sema); // 동기화 완료, 부모 프로세스 락 해제
@@ -287,7 +288,6 @@ int process_wait(tid_t child_tid UNUSED)
 		return -1;
 
 	child->wait_flag = true;
-	// timer_msleep(3000);
 	/* 자식의 wait_sema를 대기합니다. process_exit에서 wait_sema를 up 해줍니다 */
 	sema_down(&child->wait_sema);
 	int status = child->exit_status;


### PR DESCRIPTION
process.c에서 fd_table 초기화 후 NULL 확인을 추가하고 파일 복제를 위한 루프를 수정함

+ fork-read, fork-write, exec-read, multi-child-fd 통과